### PR TITLE
New type of templates: `graphite`

### DIFF
--- a/graphite/kinds/default.j2
+++ b/graphite/kinds/default.j2
@@ -1,0 +1,10 @@
+    "{{ name }}": {
+      "index": "{{ device_index }}",
+      "shortname": "{{ name }}",
+      "longname": "{{ name }}",
+      "fqdn": "{{ name }}",
+      "group": "",
+      "kind": "{{ platform_name }}",
+      "labels": {
+      }
+    }

--- a/graphite/kinds/default.j2
+++ b/graphite/kinds/default.j2
@@ -6,5 +6,8 @@
       "group": "",
       "kind": "{{ platform_name }}",
       "labels": {
+        "graph-icon": "{{ role }}",
+        {% include 'graphite/labels.j2' %}
+
       }
     }

--- a/graphite/labels.j2
+++ b/graphite/labels.j2
@@ -1,0 +1,1 @@
+        "graph-level": {{ 10 - level }}

--- a/graphite/topology.j2
+++ b/graphite/topology.j2
@@ -1,6 +1,7 @@
 {
   "name": "{{name}}",
-  "type": "nr-netbox",
+  "type": "graphite",
+  "source": "netbox",
   "nodes": {
 {% for node in nodes: %}
 {{ node }}{% if not loop.last %},{% endif %}

--- a/graphite/topology.j2
+++ b/graphite/topology.j2
@@ -1,6 +1,6 @@
 {
   "name": "{{name}}",
-  "type": "clab",
+  "type": "nr-netbox",
   "nodes": {
 {% for node in nodes: %}
 {{ node }}{% if not loop.last %},{% endif %}

--- a/graphite/topology.j2
+++ b/graphite/topology.j2
@@ -1,0 +1,27 @@
+{
+  "name": "{{name}}",
+  "type": "clab",
+  "nodes": {
+{% for node in nodes: %}
+{{ node }}{% if not loop.last %},{% endif %}
+
+{% endfor %}
+  },
+  "links": [
+{% for link in links: %}
+    {
+      "a": {
+        "node": "{{link['a']['node']}}",
+        "interface": "{{link['a']['interface']}}",
+        "peer": "z"
+      },
+      "z": {
+        "node": "{{link['b']['node']}}",
+        "interface": "{{link['b']['interface']}}",
+        "peer": "a"
+      }
+    }{% if not loop.last %},{% endif %}
+
+{% endfor %}
+  ]
+}


### PR DESCRIPTION
New type of templates `graphite` allows direct visualization of topology by netreplica graphite.