### PR TITLE
Updated Graphite template with more generic fields per node

### DIFF
--- a/graphite/kinds/default.j2
+++ b/graphite/kinds/default.j2
@@ -1,10 +1,14 @@
+{%- set primary_ip4_address = primary_ip4.split("/")[0] -%}
+{%- set primary_ip6_address = primary_ip6.split("/")[0] -%}
     "{{ name }}": {
       "index": "{{ device_index }}",
-      "shortname": "{{ name }}",
-      "longname": "{{ name }}",
-      "fqdn": "{{ name }}",
-      "group": "",
-      "kind": "{{ platform_name }}",
+      "role": "{{ role_name }}",
+      "group": "{{ site }}",
+      "platform": "{{ platform_name }}",
+      "vendor": "{{ vendor_name }}",
+      "model": "{{ model_name }}",
+      "mgmt-ipv4-address": "{{ primary_ip4_address }}",
+      "mgmt-ipv6-address": "{{ primary_ip6_address }}",
       "labels": {
         "graph-icon": "{{ role }}",
         {% include 'graphite/labels.j2' %}

--- a/graphite/kinds/default.j2
+++ b/graphite/kinds/default.j2
@@ -1,5 +1,5 @@
-{%- set primary_ip4_address = primary_ip4.split("/")[0] -%}
-{%- set primary_ip6_address = primary_ip6.split("/")[0] -%}
+{% set primary_ip4_address = primary_ip4.split("/")[0] %}
+{% set primary_ip6_address = primary_ip6.split("/")[0] %}
     "{{ name }}": {
       "index": "{{ device_index }}",
       "role": "{{ role_name }}",


### PR DESCRIPTION
```
role: device.device_role.name
group: device.device_role.name
platform: device.platform.name
vendor: device.platform.manufacturer.name or device.device_type.manufacturer.name
model: device.device_type.name
mgmt-ipv4-address: device.primary_ip4.address (netmask removed)
mgmt-ipv6-address: device.primary_ip6.address (netmask removed)
```