### PR TITLE
Reworked graphite and clab templates to use up-to-date label naming

### DIFF
--- a/clab/kinds/ceos.j2
+++ b/clab/kinds/ceos.j2
@@ -5,6 +5,4 @@
             binds:
                 - {{ interface_map }}:/mnt/flash/EosIntfMapping.json:ro
             {% endif %}
-            labels:
-                graph-icon: router
-                {% include 'clab/labels.j2' %}
+            {% include 'clab/labels.j2' %}

--- a/clab/kinds/linux.j2
+++ b/clab/kinds/linux.j2
@@ -4,6 +4,4 @@
             cmd: /start.sh -sS
             exec:
                 - bash -c "echo root:root | chpasswd"
-            labels:
-                graph-icon: server
-                {% include 'clab/labels.j2' %}
+            {% include 'clab/labels.j2' %}

--- a/clab/kinds/rare.j2
+++ b/clab/kinds/rare.j2
@@ -1,6 +1,4 @@
         {{ name }}:
             kind: rare
-            image: ghcr.io/rare-freertr/freertr-containerlab:latest 
-            labels:
-                graph-icon: router
-                {% include 'clab/labels.j2' %}
+            image: ghcr.io/rare-freertr/freertr-containerlab:latest
+            {% include 'clab/labels.j2' %}

--- a/clab/kinds/sonic-vs.j2
+++ b/clab/kinds/sonic-vs.j2
@@ -1,6 +1,4 @@
         {{ name }}:
             kind: sonic-vs
             image: netreplica/docker-sonic-vs:latest
-            labels:
-                graph-icon: switch
-                {% include 'clab/labels.j2' %}
+            {% include 'clab/labels.j2' %}

--- a/clab/kinds/srl.j2
+++ b/clab/kinds/srl.j2
@@ -2,6 +2,4 @@
             kind: nokia_srlinux
             type: ixrd2
             image: ghcr.io/nokia/srlinux:latest
-            labels:
-                graph-icon: switch
-                {% include 'clab/labels.j2' %}
+            {% include 'clab/labels.j2' %}

--- a/clab/kinds/vr-cisco_csr1000v.j2
+++ b/clab/kinds/vr-cisco_csr1000v.j2
@@ -1,6 +1,4 @@
         {{ name }}:
             kind: vr-cisco_csr1000v
             image: csr1000v:latest
-            labels:
-                graph-icon: router
-                {% include 'clab/labels.j2' %}
+            {% include 'clab/labels.j2' %}

--- a/clab/labels.j2
+++ b/clab/labels.j2
@@ -1,1 +1,8 @@
+            labels:
+                graph-icon: {{ role }}
                 graph-level: {{ 10 - level }}
+                role: {{ role_name }}
+                group: {{ site }}
+                platform: {{ platform_name }}
+                vendor: {{ vendor_name }}
+                model: {{ model_name }}

--- a/graphite/kinds/default.j2
+++ b/graphite/kinds/default.j2
@@ -2,11 +2,6 @@
 {% set primary_ip6_address = primary_ip6.split("/")[0] %}
     "{{ name }}": {
       "index": "{{ device_index }}",
-      "role": "{{ role_name }}",
-      "group": "{{ site }}",
-      "platform": "{{ platform_name }}",
-      "vendor": "{{ vendor_name }}",
-      "model": "{{ model_name }}",
       "mgmt-ipv4-address": "{{ primary_ip4_address }}",
       "mgmt-ipv6-address": "{{ primary_ip6_address }}",
       {% include 'graphite/labels.j2' %}

--- a/graphite/kinds/default.j2
+++ b/graphite/kinds/default.j2
@@ -9,9 +9,7 @@
       "model": "{{ model_name }}",
       "mgmt-ipv4-address": "{{ primary_ip4_address }}",
       "mgmt-ipv6-address": "{{ primary_ip6_address }}",
-      "labels": {
-        "graph-icon": "{{ role }}",
-        {% include 'graphite/labels.j2' %}
+      {% include 'graphite/labels.j2' %}
 
       }
     }

--- a/graphite/labels.j2
+++ b/graphite/labels.j2
@@ -1,1 +1,3 @@
+      "labels": {
+        "graph-icon": "{{ role }}",
         "graph-level": {{ 10 - level }}

--- a/graphite/labels.j2
+++ b/graphite/labels.j2
@@ -1,3 +1,8 @@
       "labels": {
         "graph-icon": "{{ role }}",
-        "graph-level": {{ 10 - level }}
+        "graph-level": {{ 10 - level }},
+        "role": "{{ role_name }}",
+        "group": "{{ site }}",
+        "platform": "{{ platform_name }}",
+        "vendor": "{{ vendor_name }}",
+        "model": "{{ model_name }}"


### PR DESCRIPTION
see https://github.com/netreplica/graphite/pull/68