### PR TITLE
Added d2 templates

### DIFF
--- a/d2/kinds/default.j2
+++ b/d2/kinds/default.j2
@@ -1,0 +1,3 @@
+{{ name }}: {
+    shape: circle
+}

--- a/d2/kinds/rare.j2
+++ b/d2/kinds/rare.j2
@@ -1,5 +1,4 @@
 {{ name }}: {
         shape: image
-        #icon: $url_to_platform_svg
         icon: https://raw.githubusercontent.com/GEANT/rare-docs/main/docs/img/xrd.svg
 }

--- a/d2/kinds/rare.j2
+++ b/d2/kinds/rare.j2
@@ -1,0 +1,5 @@
+{{ name }}: {
+        shape: image
+        #icon: $url_to_platform_svg
+        icon: https://raw.githubusercontent.com/GEANT/rare-docs/main/docs/img/xrd.svg
+}

--- a/d2/kinds/rare.j2
+++ b/d2/kinds/rare.j2
@@ -1,4 +1,4 @@
 {{ name }}: {
-        shape: image
-        icon: https://raw.githubusercontent.com/GEANT/rare-docs/main/docs/img/xrd.svg
+    shape: image
+    icon: https://raw.githubusercontent.com/GEANT/rare-docs/main/docs/img/xrd.svg
 }

--- a/d2/topology.j2
+++ b/d2/topology.j2
@@ -14,7 +14,7 @@ title: "" {
 direction: right
 
 style {
-    fill: transparent 
+    fill: transparent
 }
 
 {% for node in nodes: %}
@@ -25,5 +25,5 @@ style {
 {{link['a']['node']}} -- {{link['b']['node']}}: {
     source-arrowhead.label: {{link['a']['interface']}}
     target-arrowhead.label: {{link['b']['interface']}}
-}  
+}
 {% endfor %}

--- a/d2/topology.j2
+++ b/d2/topology.j2
@@ -1,0 +1,19 @@
+
+Topology - {{ name }}
+
+direction: right
+
+style {
+    fill: transparent 
+}
+
+{% for node in nodes: %}
+{{ node }}
+{% endfor %}
+
+{% for link in links: %}
+{{link['a']['node']}} -- {{link['b']['node']}}: {
+    source-arrowhead.label: {{link['a']['interface']}}
+    target-arrowhead.label: {{link['b']['interface']}}
+}  
+{% endfor %}

--- a/d2/topology.j2
+++ b/d2/topology.j2
@@ -1,5 +1,15 @@
+title: "" {
+  near: top-center
+  grid-columns: 2
+  grid-gap: 0
+  width: 1000
 
-Topology - {{ name }}
+  Topology.width: 500
+  Topology.style.font-size: 32
+  {{ name }}.width: 500
+  {{ name }}.style.bold: false
+  {{ name }}.style.font-size: 32
+}
 
 direction: right
 


### PR DESCRIPTION
Hi, as per your request, this is the `d2` templates i used to produce [this](https://play.d2lang.com/?script=zJY7b4MwFIV3_4ortWuw82gHb-4zGfJQki5dIjexHCTAyDh9qMp_r-zSpHgoVDCYCaGr489H957LWuUqUfKDgsxHCUInAyloe1WE3EHwiQAArHEU3AE51yIz6IjQw5IRQvq0rLGPuxOFOOVSnD5eWKMoXB50sjFqkyfcWMpN8SpPNd8le2PygmKs-VskY7M_vBwKobcqMyIz0Val-PGezdZYcy16O7UtcMrjDLu3OJX4Xe8iq3pEbLoKlm0xfw6W7ebpLli22_GEkFGYbNNJuLOwYnNCBmGyjWfh9tuCLUk_VLYlC5btJ3yh1wNvR_jrLnKbk4Iw-74r8BdbpeD4W9lL0T-UB3XKg3PwdczsKTdnHjZxowxEq-ztuzbMV1VlL9na-lyG0f-UG_VGGSUdu3FdZW6uXOvG6BwxHTMPq8rN-7mWeXiOno5n0FP2_kPazuBXAAAA__8%3D&layout=dagre&) from the global P4 lab environment.
With regard to our past exchange, i removed the symlink to rare,j2 (as we use platform in a specific a way)

Please let me know you want me to also issue a `PR `for `nrx `. This is basically a matter of adding new `--output d2` here and there. If you prefer to do it, feel free to do so. One thing also is that `d2 `export considers real `interfaces `and not `emulated interfaces`. 